### PR TITLE
feat: Preload transcripts in StaticTranslationsController show method

### DIFF
--- a/app/controllers/static_translations_controller.ts
+++ b/app/controllers/static_translations_controller.ts
@@ -76,12 +76,8 @@ export default class StaticTranslationsController {
       .where('user_id', userId!)
       .where('id', params.id)
       .select('id', 'title', 'videoUrl', 'createdAt', 'updatedAt')
+      .preload('transcripts', (query) => query.orderBy('timestamp', 'asc'))
       .first()
-
-    const staticTranslationTranscript = await StaticTranscript.query()
-      .where('static_translation_id', params.id)
-      .select('id', 'timestamp', 'text')
-      .orderBy('timestamp', 'asc')
 
     if (!staticTranslations) {
       return response.notFound(
@@ -90,10 +86,7 @@ export default class StaticTranslationsController {
     }
 
     return response.ok(
-      responseFormatter(HTTP.OK, 'success', 'Static translation found', {
-        ...staticTranslations.toJSON(),
-        transcripts: staticTranslationTranscript,
-      })
+      responseFormatter(HTTP.OK, 'success', 'Static translation found', staticTranslations)
     )
   }
 

--- a/app/models/static_translation.ts
+++ b/app/models/static_translation.ts
@@ -30,5 +30,5 @@ export default class StaticTranslation extends BaseModel {
     foreignKey: 'staticTranslationId',
     localKey: 'id',
   })
-  declare staticTranscripts: HasMany<typeof StaticTranscript>
+  declare transcripts: HasMany<typeof StaticTranscript>
 }

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -32,18 +32,6 @@ router.delete('/test', [TestsController, 'testFileDelete'])
 router.post('/test/gcp', [TestsController, 'testGoogleCloudStorage'])
 router.delete('/test/gcp', [TestsController, 'testGoogleCloudStorageDelete'])
 
-router
-  .group(() => {
-    // Multiple
-    router.get('/translation/static', [StaticTranslationsController, 'index'])
-    router.post('/translation/static', [StaticTranslationsController, 'store'])
-    // Single
-    router.get('/translation/static/:id', [StaticTranslationsController, 'show'])
-    router.patch('/translation/static/:id', [StaticTranslationsController, 'update'])
-    router.delete('/translation/static/:id', [StaticTranslationsController, 'destroy'])
-  })
-  .use(middleware.auth())
-
 // Auth
 router.post('/login', [AuthController, 'create'])
 router.post('/register', [UsersController, 'store'])
@@ -79,5 +67,13 @@ router
     // Users
     router.get('/users/me', [UsersController, 'index'])
     router.put('/users/me', [UsersController, 'update'])
+
+    // Static Translation Multiple
+    router.get('/translation/static', [StaticTranslationsController, 'index'])
+    router.post('/translation/static', [StaticTranslationsController, 'store'])
+    // Static Translation Single
+    router.get('/translation/static/:id', [StaticTranslationsController, 'show'])
+    router.put('/translation/static/:id', [StaticTranslationsController, 'update'])
+    router.delete('/translation/static/:id', [StaticTranslationsController, 'destroy'])
   })
   .middleware(middleware.auth())


### PR DESCRIPTION
This commit modifies the `show` method in the `StaticTranslationsController` to preload the `transcripts` relationship using the `preload` method. This change ensures that the transcripts are ordered by timestamp in ascending order when returning a single static translation.