### PR TITLE
feat: Add show method to ConversationNodeVideosController

### DIFF
--- a/app/controllers/conversation_node_videos_controller.ts
+++ b/app/controllers/conversation_node_videos_controller.ts
@@ -14,6 +14,36 @@ import { convertMultipartFileToFile } from '#utils/converter'
 
 export default class ConversationNodeVideosController {
   /**
+   * Show individual record
+   */
+  async show({ auth, params, response }: HttpContext) {
+    const userId = auth.use('jwt').user?.id
+
+    const conversationTranslation = await ConversationNode.query()
+      .where('user_id', userId!)
+      .where('id', params.transcriptId)
+      .where('conversation_translation_id', params.conversationTranslationId)
+      .preload('transcripts', (query) => {
+        query.orderBy('created_at', 'asc')
+      })
+      .first()
+
+    if (!conversationTranslation) {
+      return response.notFound(
+        responseFormatter(HTTP.NOT_FOUND, 'error', 'Conversation translation not found')
+      )
+    }
+
+    return response.ok(
+      responseFormatter(
+        HTTP.OK,
+        'success',
+        'Get conversation translation success',
+        conversationTranslation
+      )
+    )
+  }
+  /**
    * Handle form submission for the create action
    */
   async store({ auth, params, request, response }: HttpContext) {

--- a/app/controllers/conversation_nodes_controller.ts
+++ b/app/controllers/conversation_nodes_controller.ts
@@ -18,6 +18,7 @@ export default class ConversationNodesController {
       .preload('transcripts', (query) => {
         query.orderBy('created_at', 'asc')
       })
+      .orderBy('created_at', 'asc')
 
     let mappedConversationNode = conversationNode.map((node) => {
       return {

--- a/config/bodyparser.ts
+++ b/config/bodyparser.ts
@@ -47,7 +47,7 @@ const bodyParserConfig = defineConfig({
      * Maximum limit of data to parse including all files
      * and fields
      */
-    limit: '100mb',
+    limit: '500mb',
     types: ['multipart/form-data'],
   },
 })

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -117,6 +117,18 @@ router
     router.put('/translation/conversation/:id', [ConversationTranslationsController, 'update'])
     router.delete('/translation/conversation/:id', [ConversationTranslationsController, 'destroy'])
 
+    // Conversation Nodes Video
+    router.get('/translation/conversation/:conversationTranslationId/video/:transcriptId', [
+      ConversationNodeVideosController,
+      'show',
+    ])
+
+    // Conversation Nodes Speech
+    router.post('/translation/conversation/node/speech', [
+      ConversationNodeSpeechesController,
+      'store',
+    ])
+
     // Bulk Delete Conversation Nodes
     router.post('/translation/conversation/bulk/node', [
       BulkDeleteConversationNodesController,


### PR DESCRIPTION
This commit adds a new show method to the ConversationNodeVideosController. The show method retrieves an individual record based on the provided transcriptId and conversationTranslationId. It fetches the conversation translation and its associated transcripts, and returns a success response with the conversation translation object. If the conversation translation is not found, a not found response is returned.